### PR TITLE
fix single-digit UTM zone

### DIFF
--- a/lsdviztools/lsdplottingtools/lsdmap_gdalio.py
+++ b/lsdviztools/lsdplottingtools/lsdmap_gdalio.py
@@ -1251,9 +1251,9 @@ def convert2UTM(DataDirectory, RasterFile,minimum_elevation=0.01,resolution=30):
 
     UTMzone = temp_info[2]
     if south:
-        EPSG = "327" + str(UTMzone)
+        EPSG = f"327{UTMzone:02d}"
     else:
-        EPSG = "326" + str(UTMzone)
+        EPSG = f"326{UTMzone:02d}"
 
     res_tuple = (res,res)
     print("res tuple is:")


### PR DESCRIPTION
Uses formatted string e.g. ` EPSG = f"327{UTMzone:02d}"` to ensure leading zero is preserved for single-digit UTM zones. Tested on UTM 6N and works! Note f strings are compatible with Python >= 3.6. 